### PR TITLE
Improve `fire` and `monitor`

### DIFF
--- a/config/sample.toml
+++ b/config/sample.toml
@@ -10,8 +10,9 @@ rotate = "daily" # from Ruby Logger shift_age
 ## Common Task Settings
 # Can be overridden by each app settings
 [task]
-max_semaphores = 5
-watch_timeout  = 120 # seconds
+max_semaphores  = 5
+wait_after_fire = 15  # seconds. Don't wait if not defined
+watch_timeout   = 120 # seconds
 on_command_failure = "abort" # or "ignore". Default is "abort"
 
 # You can define common task commands for all apps here.

--- a/lib/fireap/cli.rb
+++ b/lib/fireap/cli.rb
@@ -38,9 +38,13 @@ module Fireap
 
     desc 'monitor', 'Monitor update propagation of target Application'
     option 'app', :required => true, :aliases => 'a'
+    option 'interval', :aliases => 'i'
+    option 'one-shot', :aliases => 'o'
     def monitor
       load_context(options)
-      Fireap::Monitor.new(options, @ctx).monitor(options)
+      monitor = Fireap::Monitor.new(options, @ctx)
+      return monitor.oneshot(options) if options['one-shot']
+      monitor.monitor(options)
     end
 
     private

--- a/lib/fireap/config.rb
+++ b/lib/fireap/config.rb
@@ -4,7 +4,7 @@ require 'toml'
 module Fireap
   class Config
     @@app_props = %w[
-      max_semaphores watch_timeout on_command_failure
+      max_semaphores wait_after_fire watch_timeout on_command_failure
       before_commands exec_commands after_commands
     ]
     @me   = nil
@@ -51,7 +51,7 @@ module Fireap
     end
 
     class App
-      attr :max_semaphores, :watch_timeout, :on_command_failure, :commands
+      attr :max_semaphores, :wait_after_fire, :watch_timeout, :on_command_failure, :commands
 
       def initialize(stash)
         stash.each_pair do |k,v|

--- a/lib/fireap/controller/monitor.rb
+++ b/lib/fireap/controller/monitor.rb
@@ -7,7 +7,7 @@ module Fireap
     def initialize(options, ctx)
       @appname  = options['app']
       @appdata  = Fireap::ViewModel::Application.new(options['app'], ctx)
-      @interval = 1
+      @interval = options['interval'].to_i || 2
       @ctx      = ctx
     end
 
@@ -30,7 +30,7 @@ module Fireap
       puts "End."
     end
 
-    def capture(options)
+    def oneshot(options)
       @appdata.refresh
       puts @appdata.render_text
     end

--- a/lib/fireap/manager/node.rb
+++ b/lib/fireap/manager/node.rb
@@ -16,6 +16,7 @@ module Fireap::Manager
       end
     end
 
+    # @param app [Fireap::Model::Application]
     def collect_app_info(app, ctx: nil)
       Fireap::DataAccess::Kv.get_recurse("#{app.name}/nodes/").each do |data|
         unless %r|#{app.name}/nodes/([^/]+)/([^/\s]+)$|.match(data.key)

--- a/lib/fireap/view_model/application.rb
+++ b/lib/fireap/view_model/application.rb
@@ -33,7 +33,7 @@ module Fireap::ViewModel
       <<"EOH"
 ----
 Time: #{Time.now}
-App:  "#{@appname}"
+App:  "#{@name}"
 ----
 EOH
     end
@@ -44,7 +44,7 @@ EOH
 
       @appnodes.sort.each do |an|
         tt.rows << [
-          an.appname,
+          an.nodename,
           an.version,
           an.semaphore,
           an.updated_at,

--- a/lib/fireap/view_model/application_node.rb
+++ b/lib/fireap/view_model/application_node.rb
@@ -2,7 +2,7 @@ module Fireap::ViewModel
   ##
   # A view object which has info of a particular Application and a Node.
   class ApplicationNode
-    attr :appname, :version, :semaphore, :updated_at, :remote_node
+    attr :appname, :nodename, :version, :semaphore, :updated_at, :remote_node
 
     # @param app  [Fireap::Model::Application]
     # @param node [Fireap::Model::Node]
@@ -10,8 +10,9 @@ module Fireap::ViewModel
       @app  = app
       @node = node
 
-      @appname = app.name
-      @version = app.version ? app.version.value : '-'
+      @appname  = app.name
+      @nodename = node.name
+      @version  = app.version ? app.version.value : '-'
       @semaphore   = app.semaphore   ? app.semaphore.value : '-'
       @updated_at  = app.update_info ? app.update_info.updated_at  : '-'
       @remote_node = app.update_info ? app.update_info.remote_node : '-'
@@ -21,7 +22,7 @@ module Fireap::ViewModel
     def <=>(other)
       ret = other.version <=> self.version
       return ret if ret == 0
-      self.name <=> other.name
+      self.nodename <=> other.nodename
     end
   end
 end

--- a/spec/fireap/config_spec.rb
+++ b/spec/fireap/config_spec.rb
@@ -58,6 +58,7 @@ EOS
 ## Common Task Settings
 [task]
 max_semaphores     = 5
+wait_after_fire    = 10
 watch_timeout      = 120
 on_command_failure = "abort"
 before_commands = [ "common before" ]
@@ -110,7 +111,7 @@ EOS
       parsed = tester.parsed['task']
       appc   = tester.config.app_config('bar')
 
-      %w[ max_semaphores watch_timeout on_command_failure ].each do |key|
+      %w[ max_semaphores wait_after_fire watch_timeout on_command_failure ].each do |key|
         it "#{key} - common setting is chosen" do
           expect( appc.send(key) ).to eq parsed[key]
         end


### PR DESCRIPTION
- `fire`
  - Wait for deploy propagation after fire an event.
- `monitor`
  - `--[o]ne-shot` option to print the data only once.
- And a little view bug fix.
