### PR TITLE
Improve logging and fix bug in v0.1.2

### DIFF
--- a/lib/fireap/context.rb
+++ b/lib/fireap/context.rb
@@ -27,8 +27,7 @@ module Fireap
       @log       = logger(@config.log, params[:suppress_log])
     end
 
-    def die(message, level=Logger::ERROR, err=Fireap::Error)
-      p message
+    def die(message, level=::Logger::ERROR, err=Fireap::Error)
       @log.log(level, [message, 'at', caller(1).to_s].join(%q{ }))
       raise err, message unless self.develop_mode?
     end

--- a/lib/fireap/context.rb
+++ b/lib/fireap/context.rb
@@ -42,10 +42,8 @@ module Fireap
     end
 
     def develop_mode?
-      if    @mode == 'develop' \
-        and flg = @config.enable_debugging \
-        and flg != 0 and flg.length > 0
-        @log.warn 'IN DEVELOP MODE. Called from ' + caller(1..2).to_s
+      if is_develop_mode?
+        @log.warn 'IN DEVELOP MODE. Called from ' + caller(1..2).to_s if @log
         true
       else
         false
@@ -60,7 +58,18 @@ module Fireap
         outs.push(STDOUT) if STDOUT.tty?
         outs.push(config['file']) if config['file']
       end
-      Fireap::Logger.new(outs, rotate: config['rotate'], level: config['level'])
+      headers = []
+      headers.push('## DEVELOP MODE ##') if is_develop_mode?
+      headers.push('[Dry-run]')          if dry_run?
+      Fireap::Logger.new(
+        outs, rotate: config['rotate'], level: config['level'], header: headers.join(%q[ ])
+      )
+    end
+
+    def is_develop_mode?
+          @mode == 'develop' \
+      and flg = @config.enable_debugging \
+      and flg != 0 and flg.length > 0
     end
   end
 end

--- a/lib/fireap/logger.rb
+++ b/lib/fireap/logger.rb
@@ -8,8 +8,10 @@ module Fireap
     # @param outs [Array] Log outputs. Given to Logger.new as logdev
     # @param rotate [Fixnum, String] shift_age param in Logger.new
     # @param level Log level defined as constants in Logger class
-    def initialize(outs, rotate: 0, level: 'INFO')
+    # @param header [String] Custom header for each log line
+    def initialize(outs, rotate: 0, level: 'INFO', header: '')
       @loggers = []
+      @header  = header.length > 0 ? header : nil
       outs.each do |out|
         logger = ::Logger.new(out, rotate)
         logger.level = Object.const_get("Logger::#{level}")
@@ -22,7 +24,7 @@ module Fireap
 
     def log(level=::Logger::INFO, message)
       @loggers.each do |logger|
-        logger.log(level, message, $0)
+        logger.log(level, custom_message(message), $0)
       end
     end
 
@@ -30,8 +32,16 @@ module Fireap
     # is given to Logger instances in @loggers.
     def method_missing(method, *args)
       @loggers.each do |logger|
-        logger.send(method, *args)
+        msg = custom_message(args[0])
+        new_args = args[1 .. args.size-1]
+        logger.send(method, msg, *new_args)
       end
+    end
+
+    private
+
+    def custom_message(message)
+      @header ? "#{@header} #{message}" : message
     end
   end
 end

--- a/lib/fireap/logger.rb
+++ b/lib/fireap/logger.rb
@@ -13,8 +13,9 @@ module Fireap
       @loggers = []
       @header  = header.length > 0 ? header : nil
       outs.each do |out|
-        logger = ::Logger.new(out, rotate)
-        logger.level = Object.const_get("Logger::#{level}")
+        logger           = ::Logger.new(out, rotate)
+        logger.level     = Object.const_get("Logger::#{level}")
+        logger.progname  = [$0, ARGV].join(%q[ ])
         logger.formatter = proc do |level, date, prog, msg|
           "#{date} [#{level}] #{msg} -- #{prog}\n"
         end
@@ -24,7 +25,7 @@ module Fireap
 
     def log(level=::Logger::INFO, message)
       @loggers.each do |logger|
-        logger.log(level, custom_message(message), $0)
+        logger.log(level, custom_message(message))
       end
     end
 
@@ -41,7 +42,8 @@ module Fireap
     private
 
     def custom_message(message)
-      @header ? "#{@header} #{message}" : message
+      customized = [message, 'at', caller(4, 1).to_s].join(%q[ ])
+      @header ? "#{@header} #{customized}" : customized
     end
   end
 end

--- a/lib/fireap/logger.rb
+++ b/lib/fireap/logger.rb
@@ -20,7 +20,7 @@ module Fireap
       end
     end
 
-    def log(message, level=::Logger::INFO)
+    def log(level=::Logger::INFO, message)
       @loggers.each do |logger|
         logger.log(level, message, $0)
       end

--- a/spec/fireap/logger_spec.rb
+++ b/spec/fireap/logger_spec.rb
@@ -1,0 +1,72 @@
+require 'fireap/logger'
+
+require 'logger'
+
+class LoggerTester
+  attr :logger, :outs
+  def initialize(level, header)
+    # Create output devices for test
+    @outs   = (0..1).map do StringIO.new end
+    @logger = Fireap::Logger.new(@outs, level: level, header: header)
+  end
+end
+
+describe 'Fireap::Logger' do
+  context 'when multi outputs are given with header and WARN level' do
+    header = ':: head ::'
+    message = 'test log message'
+
+    describe "#log with [WARN] level logger. Message='#{message}'" do
+      level  = 'WARN'
+
+      context %q{given level [ERROR], log appears} do
+        tester = LoggerTester.new(level, header)
+        tester.logger.log(Logger::ERROR, message)
+
+        tester.outs.each_with_index do |out, idx|
+          expected = /\[ERROR\] #{header} #{message}/
+          it "out[#{idx}] matches #{expected}" do
+            expect(out.string).to match expected
+          end
+        end
+      end
+
+      context %q{given level [INFO], log wan't appear} do
+        tester = LoggerTester.new(level, header)
+        tester.logger.log(Logger::INFO, message)
+
+        tester.outs.each_with_index do |out, idx|
+          it "out[#{idx}] has no output" do
+            expect(out.string).to eq ''
+          end
+        end
+      end
+    end
+
+    describe "#debug Message='#{message}'" do
+      context "when logger level=INFO" do
+        tester = LoggerTester.new('INFO', header)
+        tester.logger.debug(message)
+
+        tester.outs.each_with_index do |out, idx|
+          it "out[#{idx}] has no output" do
+            expect(out.string).to eq ''
+          end
+        end
+      end
+
+      context "when logger level=DEBUG" do
+        tester = LoggerTester.new('DEBUG', header)
+        tester.logger.debug(message)
+
+        tester.outs.each_with_index do |out, idx|
+          expected = /\[DEBUG\] #{header} #{message}/
+          it "out[#{idx}] matches #{expected}" do
+            expect(out.string).to match expected
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/fireap/logger_spec.rb
+++ b/spec/fireap/logger_spec.rb
@@ -24,7 +24,7 @@ describe 'Fireap::Logger' do
         tester.logger.log(Logger::ERROR, message)
 
         tester.outs.each_with_index do |out, idx|
-          expected = /\[ERROR\] #{header} #{message}/
+          expected = /\[ERROR\] #{header} #{message} at /
           it "out[#{idx}] matches #{expected}" do
             expect(out.string).to match expected
           end
@@ -60,7 +60,7 @@ describe 'Fireap::Logger' do
         tester.logger.debug(message)
 
         tester.outs.each_with_index do |out, idx|
-          expected = /\[DEBUG\] #{header} #{message}/
+          expected = /\[DEBUG\] #{header} #{message} at /
           it "out[#{idx}] matches #{expected}" do
             expect(out.string).to match expected
           end


### PR DESCRIPTION
Bug Fix:
- Add `::` before `Logger::` constant - https://github.com/key-amb/fireap/commit/d97c6f62019960701d07c61be379ded2908ecf6b
  - In v0.1.2, when command fails in `reap` mode, program exits irregularly.

Improve:
- Show caller info and full command-line on every log line.
- Add `[Dry-run]` string as header with each log line when `--dry-run` option is given for `fireap reap`.
